### PR TITLE
Allow to specify HTTP method for urllib

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ server     | ((string))(_required_)           | Remote server to upload.
 data       | ((object))                       | The data will put in the field and send to server.If it is a function, it should return result.
 fileinputname | ((string))                    | To define the name of API.
 timeout    | ((number))                       | It will be used in urllib.
+method     | ((string))                       | It will be used in urllib.
 headers    | ((object))                       | It will be used in urllib.
 callback   | ((function))                     | It will be used in urllib. [More](https://github.com/node-modules/urllib)
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(options) {
     form.file(fileinputname, file.path);
 
     urllib.request(options.server, {
-      method: 'post',
+      method: options.method || 'post',
       timeout: options.timeout || 5000,
       headers: form.headers(options.headers),
       stream: form


### PR DESCRIPTION
Sometimes it is helpful to be able to change the base HTTP method. of the upload request.
For example nGinx requires PUT method for file upload (without using Upload plugin).