### PR TITLE
Supporting Basic Authentication Param

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ fileinputname | ((string))                    | To define the name of API.
 timeout    | ((number))                       | It will be used in urllib.
 method     | ((string))                       | It will be used in urllib.
 headers    | ((object))                       | It will be used in urllib.
+auth       | ((string))                       | It will be used in urllib (example, `username:password`)
 callback   | ((function))                     | It will be used in urllib. [More](https://github.com/node-modules/urllib)
 
 ## License

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = function(options) {
     urllib.request(options.server, {
       method: options.method || 'post',
       timeout: options.timeout || 5000,
+      auth: options.auth,
       headers: form.headers(options.headers),
       stream: form
     }, function (err, data, res) {


### PR DESCRIPTION
I wanted to upload a file to a server that requires a basic authentication. As a work around, I concat my username and password in the URL (e.g. http://username:password@myserver:8080/fileupload).

I found out urllib already supports this. In this pull request, I created a new parameter, `auth`, that I eventually pass to urllib.